### PR TITLE
Update /dev/bus/usb directory only if it exists

### DIFF
--- a/src/docker-entrypoint
+++ b/src/docker-entrypoint
@@ -38,7 +38,8 @@ MONITOR $UPS_NAME@localhost 1 monitor $API_PASSWORD master
 SHUTDOWNCMD "$SHUTDOWN_CMD"
 EOF
 
-chgrp -R nut /etc/nut /dev/bus/usb
+test -d /dev/bus/usb && chgrp -R nut /dev/bus/usb
+chgrp -R nut /etc/nut
 chmod -R o-rwx /etc/nut
 
 /usr/sbin/upsdrvctl start


### PR DESCRIPTION
Make the chgrp of /dev/bus/usb conditional on the directory existing.

When not using the usbhid-ups driver the /dev/bus/usb directory may not exist which results in the container failing to start with the below entry in the container log.

```
+ chgrp -R nut /etc/nut /dev/bus/usb
chgrp: /dev/bus/usb: No such file or directory
```